### PR TITLE
feat: use clap as the cli builder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,10 @@ categories = ["command-line-utilities", "compilers", "parser-implementations"]
 
 [dependencies]
 chrono = "0.4"
-structopt = "0.3"
-bitflags = "1.3.2"
+clap = { version = "4.4.7", features = ["derive"] }
+bitflags = "2.4.1"
 bumpalo = { version = "3.9.1", features = ["collections", "boxed"] }
-hashbrown = { version = "0.12.0", features = ["bumpalo"] }
+hashbrown = { version = "0.14.2" }
 dtoa = "1"
 
 [dev-dependencies]

--- a/src/bin/jsonata.rs
+++ b/src/bin/jsonata.rs
@@ -1,23 +1,23 @@
 use bumpalo::Bump;
+use clap::Parser;
 use std::path::PathBuf;
-use structopt::StructOpt;
 
 use jsonata::JsonAta;
 
 /// A command line JSON processor using JSONata
-#[derive(StructOpt)]
-#[structopt(name = "jsonata")]
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
 struct Opt {
     /// Parse the given expression, print the AST and exit
-    #[structopt(short, long)]
+    #[arg(short, long)]
     ast: bool,
 
     /// File containing the JSONata expression to evaluate (overrides expr on command line)
-    #[structopt(short, long, parse(from_os_str))]
+    #[arg(short, long)]
     expr_file: Option<PathBuf>,
 
     /// Input JSON file (if not specified, STDIN)
-    #[structopt(short, long, parse(from_os_str))]
+    #[arg(short, long)]
     input_file: Option<PathBuf>,
 
     /// JSONata expression to evaluate
@@ -28,7 +28,7 @@ struct Opt {
 }
 
 fn main() {
-    let opt = Opt::from_args();
+    let opt = Opt::parse();
 
     let expr = match opt.expr_file {
         Some(expr_file) => {

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -730,7 +730,7 @@ impl<'a> Evaluator<'a> {
                 result = Value::wrap_in_array(
                     self.arena,
                     result,
-                    flags | ArrayFlags::SEQUENCE | ArrayFlags::SINGLETON,
+                    flags.clone() | ArrayFlags::SEQUENCE | ArrayFlags::SINGLETON,
                 );
             }
             result = result.clone_array_with_flags(self.arena, flags | ArrayFlags::SINGLETON);

--- a/src/evaluator/value.rs
+++ b/src/evaluator/value.rs
@@ -20,6 +20,7 @@ use self::serialize::{DumpFormatter, PrettyFormatter, Serializer};
 pub use iterator::MemberIterator;
 
 bitflags! {
+    #[derive(Clone)]
     pub struct ArrayFlags: u8 {
         const SEQUENCE     = 0b00000001;
         const SINGLETON    = 0b00000010;
@@ -480,14 +481,14 @@ impl<'a> Value<'a> {
     }
 
     pub fn get_flags(&self) -> ArrayFlags {
-        match *self {
-            Value::Array(_, flags) => flags,
+        match self {
+            Value::Array(_, flags) => flags.clone(),
             _ => panic!("Not an array"),
         }
     }
 
     pub fn has_flags(&self, check_flags: ArrayFlags) -> bool {
-        match *self {
+        match self {
             Value::Array(_, flags) => flags.contains(check_flags),
             _ => false,
         }
@@ -500,7 +501,7 @@ impl<'a> Value<'a> {
             Self::Number(n) => Value::number(arena, *n),
             Self::Bool(b) => Value::bool(arena, *b),
             Self::String(s) => Value::string(arena, s),
-            Self::Array(a, f) => Value::array_from(a, arena, *f),
+            Self::Array(a, f) => Value::array_from(a, arena, f.clone()),
             Self::Object(o) => Value::object_from(o, arena),
             Self::Lambda { ast, input, frame } => Value::lambda(arena, ast, input, frame.clone()),
             Self::NativeFn { name, arity, func } => Value::nativefn(arena, name, *arity, *func),


### PR DESCRIPTION
Remove the `structopt` which is in maintenance mode in favor of clap.

This should also remove the dependency on atty which has a vulnerability