### PR TITLE
refactor: remove hashbrown in favor on std::collections::hash_map

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ target
 Cargo.lock
 .vscode
 .nvimrc
+.data

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ chrono = "0.4"
 clap = { version = "4.4.7", features = ["derive"] }
 bitflags = "2.4.1"
 bumpalo = { version = "3.9.1", features = ["collections", "boxed"] }
-hashbrown = { version = "0.14.2" }
 dtoa = "1"
 
 [dev-dependencies]

--- a/src/evaluator/value.rs
+++ b/src/evaluator/value.rs
@@ -1,9 +1,9 @@
 use std::borrow::Cow;
+use std::collections::{hash_map, HashMap};
 
 use bitflags::bitflags;
 use bumpalo::boxed::Box;
 use bumpalo::Bump;
-use hashbrown::HashMap;
 
 use super::frame::Frame;
 use super::functions::FunctionContext;
@@ -326,7 +326,7 @@ impl<'a> Value<'a> {
         }
     }
 
-    pub fn entries(&self) -> hashbrown::hash_map::Iter<'_, String, &'a Value> {
+    pub fn entries(&self) -> hash_map::Iter<'_, String, &'a Value> {
         match self {
             Value::Object(map) => map.iter(),
             _ => panic!("Not an object"),


### PR DESCRIPTION
Hashbrown got integrated into the std library several rust version back, let's just use the std library.