### PR TITLE
chore: bump the version of the package to 0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Initial version published to crates.io.
 
-## [0.1.2] - 2022-05-28
+## [0.1.2] - 2024-04-28
 
 Adding support for base64 encoding decoding, thanks to nated0g for the contribution.
+
+## [0.1.3] - 2024-05-09
+
+- Support for `jsonata.register_function`
+- Support for evaluation with bindings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jsonata-rs"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["stedi developers"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,8 +2,8 @@
 name = "jsonata-rs"
 version = "0.1.3"
 edition = "2021"
-license = "MIT OR Apache-2.0"
-authors = ["stedi developers"]
+license = "Apache-2.0"
+authors = ["Stedi"]
 description = "An (incomplete) implementation of JSONata in Rust"
 homepage = "https://github.com/Stedi/jsonata-rs/"
 repository = "https://github.com/Stedi/jsonata-rs/"


### PR DESCRIPTION
- Support for `jsonata.register_function`
- Support for evaluation with bindings