### PR TITLE
refactor: use bumpalo collections to reduce memory footprint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,12 @@ categories = ["command-line-utilities", "compilers", "parser-implementations"]
 chrono = "0.4.38"
 clap = { version = "4.5.4", features = ["derive"] }
 bitflags = "2.5.0"
-bumpalo = { version = "3.16.0", features = ["collections", "boxed"] }
+bumpalo = { version = "3.16.0", features = [
+    "collections",
+    "boxed",
+    "allocator-api2",
+] }
+hashbrown = "0.14.5"
 dtoa = "1.0.9"
 base64 = "0.22.1"
 serde_json = "1.0.117"

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -98,7 +98,7 @@ impl<'a> Evaluator<'a> {
         let mut result = match node.kind {
             AstKind::Null => Value::null(self.arena),
             AstKind::Bool(b) => Value::bool(self.arena, b),
-            AstKind::String(ref s) => Value::string(self.arena, String::from(s)),
+            AstKind::String(ref s) => Value::string(self.arena, s),
             AstKind::Number(n) => Value::number(self.arena, n),
             AstKind::Block(ref exprs) => self.evaluate_block(exprs, input, frame)?,
             AstKind::Unary(ref op) => self.evaluate_unary_op(node, op, input, frame)?,
@@ -557,7 +557,7 @@ impl<'a> Evaluator<'a> {
                         .as_str(),
                     );
                 }
-                Ok(Value::string(self.arena, result))
+                Ok(Value::string(self.arena, &result))
             }
 
             BinaryOp::And => Ok(Value::bool(

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -767,7 +767,7 @@ impl<'a> Evaluator<'a> {
             return Ok(result);
         }
 
-        let result = Value::array(self.arena, ArrayFlags::SEQUENCE);
+        let result = Value::array_with_capacity(self.arena, input.len(), ArrayFlags::SEQUENCE);
 
         // Evaluate the step on each member of the input
         for (item_index, item) in input.members().enumerate() {
@@ -799,7 +799,8 @@ impl<'a> Evaluator<'a> {
                 result.get_member(0)
             } else {
                 // Flatten the result sequence
-                let result_sequence = Value::array(self.arena, ArrayFlags::SEQUENCE);
+                let result_sequence =
+                    Value::array_with_capacity(self.arena, result.len(), ArrayFlags::SEQUENCE);
 
                 for result_item in result.members() {
                     if !result_item.is_array() || result_item.has_flags(ArrayFlags::CONS) {

--- a/src/evaluator/frame.rs
+++ b/src/evaluator/frame.rs
@@ -23,7 +23,7 @@ impl<'a> Frame<'a> {
     pub fn from_tuple(parent: &Frame<'a>, tuple: &'a Value<'a>) -> Frame<'a> {
         let mut bindings = HashMap::with_capacity(tuple.entries().len());
         for (key, value) in tuple.entries() {
-            bindings.insert(key.clone(), *value);
+            bindings.insert(key.to_string(), *value);
         }
 
         Frame(Rc::new(RefCell::new(FrameData {

--- a/src/evaluator/functions.rs
+++ b/src/evaluator/functions.rs
@@ -309,7 +309,7 @@ pub fn fn_each<'a>(context: FunctionContext<'a, '_>, args: &'a Value<'a>) -> Res
 
     for (key, value) in obj.entries() {
         let args = Value::array(context.arena, ArrayFlags::empty());
-        let key = Value::string(context.arena, key.to_string());
+        let key = Value::string(context.arena, key);
 
         args.push(value);
         args.push(key);
@@ -357,7 +357,7 @@ pub fn fn_keys<'a>(context: FunctionContext<'a, '_>, args: &'a Value<'a>) -> Res
 
     let result = Value::array(context.arena, ArrayFlags::SEQUENCE);
     for key in keys {
-        result.push(Value::string(context.arena, key));
+        result.push(Value::string(context.arena, &key));
     }
 
     Ok(result)
@@ -429,17 +429,17 @@ pub fn fn_string<'a>(
     if input.is_string() {
         Ok(input)
     } else if input.is_function() {
-        Ok(Value::string(context.arena, String::from("")))
+        Ok(Value::string(context.arena, ""))
     } else if input.is_number() && !input.is_finite() {
         Err(Error::D3001StringNotFinite(context.char_index))
     } else if *pretty == true {
         let serializer = Serializer::new(PrettyFormatter::default(), true);
         let output = serializer.serialize(input)?;
-        Ok(Value::string(context.arena, output))
+        Ok(Value::string(context.arena, &output))
     } else {
         let serializer = Serializer::new(DumpFormatter, true);
         let output = serializer.serialize(input)?;
-        Ok(Value::string(context.arena, output))
+        Ok(Value::string(context.arena, &output))
     }
 }
 
@@ -462,7 +462,7 @@ pub fn fn_lowercase<'a>(
     Ok(if !arg.is_string() {
         Value::undefined()
     } else {
-        Value::string(context.arena, arg.as_str().to_lowercase())
+        Value::string(context.arena, &arg.as_str().to_lowercase())
     })
 }
 
@@ -475,7 +475,7 @@ pub fn fn_uppercase<'a>(
     if !arg.is_string() {
         Ok(Value::undefined())
     } else {
-        Ok(Value::string(context.arena, arg.as_str().to_uppercase()))
+        Ok(Value::string(context.arena, &arg.as_str().to_uppercase()))
     }
 }
 
@@ -501,7 +501,7 @@ pub fn fn_trim<'a>(context: FunctionContext<'a, '_>, args: &'a Value<'a>) -> Res
                 result
             }
         };
-        Ok(Value::string(context.arena, trimmed))
+        Ok(Value::string(context.arena, &trimmed))
     }
 }
 
@@ -538,16 +538,13 @@ pub fn fn_substring<'a>(
     let start = if start < 0 { len + start } else { start };
 
     if length.is_undefined() {
-        Ok(Value::string(
-            context.arena,
-            string[start as usize..].to_string(),
-        ))
+        Ok(Value::string(context.arena, &string[start as usize..]))
     } else {
         assert_arg!(length.is_number(), context, 3);
 
         let length = length.as_isize();
         if length < 0 {
-            Ok(Value::string(context.arena, String::from("")))
+            Ok(Value::string(context.arena, ""))
         } else {
             let end = if start >= 0 {
                 (start + length) as usize
@@ -561,7 +558,7 @@ pub fn fn_substring<'a>(
                 .take(end - start as usize)
                 .collect::<String>();
 
-            Ok(Value::string(context.arena, substring))
+            Ok(Value::string(context.arena, &substring))
         }
     }
 }
@@ -633,7 +630,7 @@ pub fn fn_replace<'a>(
         str_value.replace(&pattern_value.to_string(), &replacement_value)
     };
 
-    Ok(Value::string(context.arena, replaced_string))
+    Ok(Value::string(context.arena, &replaced_string))
 }
 
 pub fn fn_split<'a>(
@@ -1045,7 +1042,7 @@ pub fn fn_join<'a>(context: FunctionContext<'a, '_>, args: &'a Value<'a>) -> Res
         }
     }
 
-    Ok(Value::string(context.arena, result))
+    Ok(Value::string(context.arena, &result))
 }
 
 pub fn fn_sort<'a, 'e>(
@@ -1165,7 +1162,7 @@ pub fn fn_base64_encode<'a>(
 
     let encoded = base64.encode(arg.as_str().as_bytes());
 
-    Ok(Value::string(context.arena, encoded))
+    Ok(Value::string(context.arena, &encoded))
 }
 
 pub fn fn_base64_decode<'a>(
@@ -1185,5 +1182,5 @@ pub fn fn_base64_decode<'a>(
     let data = decoded.map_err(|e| Error::D3137Error(e.to_string()))?;
     let decoded = String::from_utf8(data).map_err(|e| Error::D3137Error(e.to_string()))?;
 
-    Ok(Value::string(context.arena, decoded))
+    Ok(Value::string(context.arena, &decoded))
 }


### PR DESCRIPTION
We were able to process the 100mb json file in lambda in 33s:

```
REPORT RequestId: f5c1569e-2149-48e8-bfa9-15891ae98739	Duration: 33287.65 ms	Billed Duration: 33639 ms	Memory Size: 10240 MB	Max Memory Used: 9122 MB	Init Duration: 350.64 ms
```

However, the API call still failed because the response was too large for ALB. (At least, that's what we think caused the failure.)

![CleanShot 2024-06-21 at 14 50 20@2x](https://github.com/Stedi/jsonata-rs/assets/27465/4ff1bec6-1934-4942-94c0-2979247ce0a3)
