### PR TITLE
refactor: use a slice to pass function arguments

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@ impl<'a> JsonAta<'a> {
         &self,
         name: &str,
         arity: usize,
-        implementation: fn(FunctionContext<'a, '_>, &'a Value<'a>) -> Result<&'a Value<'a>>,
+        implementation: fn(FunctionContext<'a, '_>, &[&'a Value<'a>]) -> Result<&'a Value<'a>>,
     ) {
         self.frame.bind(
             name,


### PR DESCRIPTION
This should allow use a temporary vec/slice when calling fuctions, which will allow us to release memory for function calls that will not be needed in the result. We are hoping this will lower our overall memory footprint.