### PR TITLE
refactor: create TRUE and FALSE constants

### DIFF
--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -98,7 +98,7 @@ impl<'a> Evaluator<'a> {
 
         let mut result = match node.kind {
             AstKind::Null => Value::null(self.arena),
-            AstKind::Bool(b) => Value::bool(self.arena, b),
+            AstKind::Bool(b) => Value::bool(b),
             AstKind::String(ref s) => Value::string(self.arena, s),
             AstKind::Number(n) => Value::number(self.arena, n),
             AstKind::Block(ref exprs) => self.evaluate_block(exprs, input, frame)?,
@@ -450,29 +450,23 @@ impl<'a> Evaluator<'a> {
                 if lhs.is_number() && rhs.is_number() {
                     let lhs = lhs.as_f64();
                     let rhs = rhs.as_f64();
-                    return Ok(Value::bool(
-                        self.arena,
-                        match op {
-                            BinaryOp::LessThan => lhs < rhs,
-                            BinaryOp::LessThanEqual => lhs <= rhs,
-                            BinaryOp::GreaterThan => lhs > rhs,
-                            BinaryOp::GreaterThanEqual => lhs >= rhs,
-                            _ => unreachable!(),
-                        },
-                    ));
+                    return Ok(Value::bool(match op {
+                        BinaryOp::LessThan => lhs < rhs,
+                        BinaryOp::LessThanEqual => lhs <= rhs,
+                        BinaryOp::GreaterThan => lhs > rhs,
+                        BinaryOp::GreaterThanEqual => lhs >= rhs,
+                        _ => unreachable!(),
+                    }));
                 }
 
                 if let (Value::String(ref lhs), Value::String(ref rhs)) = (lhs, rhs) {
-                    return Ok(Value::bool(
-                        self.arena,
-                        match op {
-                            BinaryOp::LessThan => lhs < rhs,
-                            BinaryOp::LessThanEqual => lhs <= rhs,
-                            BinaryOp::GreaterThan => lhs > rhs,
-                            BinaryOp::GreaterThanEqual => lhs >= rhs,
-                            _ => unreachable!(),
-                        },
-                    ));
+                    return Ok(Value::bool(match op {
+                        BinaryOp::LessThan => lhs < rhs,
+                        BinaryOp::LessThanEqual => lhs <= rhs,
+                        BinaryOp::GreaterThan => lhs > rhs,
+                        BinaryOp::GreaterThanEqual => lhs >= rhs,
+                        _ => unreachable!(),
+                    }));
                 }
 
                 Err(Error::T2009BinaryOpMismatch(
@@ -487,17 +481,14 @@ impl<'a> Evaluator<'a> {
                 let rhs = self.evaluate(rhs_ast, input, frame)?;
 
                 if lhs.is_undefined() || rhs.is_undefined() {
-                    return Ok(Value::bool(self.arena, false));
+                    return Ok(Value::bool(false));
                 }
 
-                Ok(Value::bool(
-                    self.arena,
-                    match op {
-                        BinaryOp::Equal => lhs == rhs,
-                        BinaryOp::NotEqual => lhs != rhs,
-                        _ => unreachable!(),
-                    },
-                ))
+                Ok(Value::bool(match op {
+                    BinaryOp::Equal => lhs == rhs,
+                    BinaryOp::NotEqual => lhs != rhs,
+                    _ => unreachable!(),
+                }))
             }
 
             BinaryOp::Range => {
@@ -555,12 +546,10 @@ impl<'a> Evaluator<'a> {
             }
 
             BinaryOp::And => Ok(Value::bool(
-                self.arena,
                 lhs.is_truthy() && self.evaluate(rhs_ast, input, frame)?.is_truthy(),
             )),
 
             BinaryOp::Or => Ok(Value::bool(
-                self.arena,
                 lhs.is_truthy() || self.evaluate(rhs_ast, input, frame)?.is_truthy(),
             )),
 
@@ -612,18 +601,18 @@ impl<'a> Evaluator<'a> {
                 let rhs = self.evaluate(rhs_ast, input, frame)?;
 
                 if lhs.is_undefined() || rhs.is_undefined() {
-                    return Ok(Value::bool(self.arena, false));
+                    return Ok(Value::bool(false));
                 }
 
                 let rhs = Value::wrap_in_array_if_needed(self.arena, rhs, ArrayFlags::empty());
 
                 for item in rhs.members() {
                     if item == lhs {
-                        return Ok(Value::bool(self.arena, true));
+                        return Ok(Value::bool(true));
                     }
                 }
 
-                Ok(Value::bool(self.arena, false))
+                Ok(Value::bool(false))
             }
 
             _ => unimplemented!("TODO: binary op not supported yet: {:#?}", *op),

--- a/src/evaluator/functions.rs
+++ b/src/evaluator/functions.rs
@@ -155,30 +155,30 @@ pub fn fn_boolean<'a>(
     let arg = args.first().copied().unwrap_or_else(Value::undefined);
     Ok(match arg {
         Value::Undefined => Value::undefined(),
-        Value::Null => Value::bool(context.arena, false),
-        Value::Bool(b) => Value::bool(context.arena, *b),
+        Value::Null => Value::bool(false),
+        Value::Bool(b) => Value::bool(*b),
         Value::Number(n) => {
             arg.is_valid_number()?;
-            Value::bool(context.arena, *n != 0.0)
+            Value::bool(*n != 0.0)
         }
-        Value::String(ref str) => Value::bool(context.arena, !str.is_empty()),
-        Value::Object(ref obj) => Value::bool(context.arena, !obj.is_empty()),
+        Value::String(ref str) => Value::bool(!str.is_empty()),
+        Value::Object(ref obj) => Value::bool(!obj.is_empty()),
         Value::Array { .. } => match arg.len() {
-            0 => Value::bool(context.arena, false),
+            0 => Value::bool(false),
             1 => fn_boolean(context.clone(), &[arg.get_member(0)])?,
             _ => {
                 for item in arg.members() {
                     if fn_boolean(context.clone(), &[item])?.as_bool() {
-                        return Ok(Value::bool(context.arena, true));
+                        return Ok(Value::bool(true));
                     }
                 }
-                Value::bool(context.arena, false)
+                Value::bool(false)
             }
         },
         Value::Lambda { .. } | Value::NativeFn { .. } | Value::Transformer { .. } => {
-            Value::bool(context.arena, false)
+            Value::bool(false)
         }
-        Value::Range(ref range) => Value::bool(context.arena, !range.is_empty()),
+        Value::Range(ref range) => Value::bool(!range.is_empty()),
     })
 }
 
@@ -420,7 +420,7 @@ pub fn fn_string<'a>(
 }
 
 pub fn fn_not<'a>(
-    context: FunctionContext<'a, '_>,
+    _context: FunctionContext<'a, '_>,
     args: &[&'a Value<'a>],
 ) -> Result<&'a Value<'a>> {
     let arg = args.first().copied().unwrap_or_else(Value::undefined);
@@ -428,7 +428,7 @@ pub fn fn_not<'a>(
     Ok(if arg.is_undefined() {
         Value::undefined()
     } else {
-        Value::bool(context.arena, !arg.is_truthy())
+        Value::bool(!arg.is_truthy())
     })
 }
 
@@ -562,10 +562,7 @@ pub fn fn_contains<'a>(
     let str_value = str_value.as_str();
     let token_value = token_value.as_str();
 
-    Ok(Value::bool(
-        context.arena,
-        str_value.contains(&token_value.to_string()),
-    ))
+    Ok(Value::bool(str_value.contains(&token_value.to_string())))
 }
 
 pub fn fn_replace<'a>(
@@ -871,8 +868,8 @@ pub fn fn_exists<'a>(
     let arg = args.first().copied().unwrap_or_else(Value::undefined);
 
     match arg {
-        Value::Undefined => Ok(Value::bool(context.arena, false)),
-        _ => Ok(Value::bool(context.arena, true)),
+        Value::Undefined => Ok(Value::bool(false)),
+        _ => Ok(Value::bool(true)),
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@ impl<'a> JsonAta<'a> {
     fn json_value_to_value(&self, json_value: &serde_json::Value) -> &'a mut Value<'a> {
         return match json_value {
             serde_json::Value::Null => Value::null(self.arena),
-            serde_json::Value::Bool(b) => Value::bool(self.arena, *b),
+            serde_json::Value::Bool(b) => self.arena.alloc(Value::Bool(*b)),
             serde_json::Value::Number(n) => Value::number(self.arena, n.as_f64().unwrap()),
             serde_json::Value::String(s) => Value::string(self.arena, s),
 
@@ -219,9 +219,9 @@ mod tests {
     fn register_function_filter_even() {
         let arena = Bump::new();
         let jsonata = JsonAta::new("$filter([1,4,9,16], $even)", &arena).unwrap();
-        jsonata.register_function("even", 1, |ctx, args| {
+        jsonata.register_function("even", 1, |_ctx, args| {
             let num = &args[0];
-            return Ok(Value::bool(ctx.arena, (num.as_f64()) % 2.0 == 0.0));
+            return Ok(Value::bool((num.as_f64()) % 2.0 == 0.0));
         });
 
         let result = jsonata.evaluate(Some(r#"anything"#), None);


### PR DESCRIPTION
`Value::Bool` can only have two values, so let's create constants for them so that we don't have to allocate a fresh `Value` everytime a bool is needed.

On a 100MB file it saves about 300MB of memory.