### PR TITLE
fix: Allow tests to run on Windows

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -19,7 +19,7 @@ fn main() {
                 #[test]
                 #[ignore]
                 fn test_{}() {{
-                    test_case("{}");
+                    test_case(r"{}");
                 }}
                 "#,
                 sanitize_filename(&resource),
@@ -32,7 +32,7 @@ fn main() {
                 r#"
                 #[test]
                 fn test_{}() {{
-                    test_case("{}");
+                    test_case(r"{}");
                 }}
                 "#,
                 sanitize_filename(&resource),


### PR DESCRIPTION
Compilation error from `generated_tests.rs` on Windows due to OS-specific forward slashes being interpreted as character escapes in generated source strings:
```
error: unknown character escape: `g`
 --> C:\jsonata-rs\target\debug\build\jsonata-rs\out\generated_tests.rs:4:48
  |
4 | test_case("tests\testsuite\groups\array-constructor\case000.json");
  |                            ^ unknown character escape
  |
help: for more info, visit https://doc.rust-lang.org/reference/tokens.html#literals
help: if you meant to write a literal backslash
         (perhaps escaping in a regular expression), consider a raw string literal
  |
4 | test_case(r"tests\testsuite\groups\array-constructor\case000.json");
  |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
Generated raw string literals are now platform agnostic 🎉🪟🐧🍎🎊