### PR TITLE
feat: support a custom fn to handle regex pattern

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ dtoa = "1.0.9"
 base64 = "0.22.1"
 serde_json = "1.0.117"
 rand = "0.8.5"
+regex = "1.11.1"
 num-format = "0.4.4"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,6 +146,7 @@ impl<'a> JsonAta<'a> {
         bind_native!("lookup", 2, fn_lookup);
         bind_native!("lowercase", 1, fn_lowercase);
         bind_native!("map", 2, fn_map);
+        bind_native!("match_regex", 2, fn_match_regex);
         bind_native!("max", 1, fn_max);
         bind_native!("merge", 1, fn_merge);
         bind_native!("min", 1, fn_min);
@@ -710,5 +711,36 @@ mod tests {
 
         // Since the array contains only one element "data", it should return "data"
         assert_eq!(result.as_str(), "data"); // Expecting the string "data" as the result
+    }
+
+    #[test]
+    fn test_match_regex_with_jsonata() {
+        let arena = Bump::new();
+
+        // Test case with a valid postal code
+        let jsonata = JsonAta::new(r#"$match_regex("123456789", "^[0-9]{9}$")"#, &arena).unwrap();
+        let result = jsonata.evaluate(None, None).unwrap();
+
+        // Assert that the result is the postal code itself, indicating a valid match
+        assert_eq!(result.as_str(), "123456789");
+
+        // Test case with an invalid postal code
+        let jsonata_invalid =
+            JsonAta::new(r#"$match_regex("12345-6789", "^[0-9]{9}$")"#, &arena).unwrap();
+
+        let result_invalid = jsonata_invalid.evaluate(None, None);
+
+        // Check if an error occurred and ensure it contains the expected message
+        assert!(result_invalid.is_err());
+        if let Err(error) = result_invalid {
+            // The core error message to match against
+            let expected_message =
+                "Invalid format: '12345-6789' does not match the expected pattern '^[0-9]{9}$'";
+            assert!(
+                error.to_string().contains(expected_message),
+                "Unexpected error message: {}",
+                error
+            );
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,7 +146,7 @@ impl<'a> JsonAta<'a> {
         bind_native!("lookup", 2, fn_lookup);
         bind_native!("lowercase", 1, fn_lowercase);
         bind_native!("map", 2, fn_map);
-        bind_native!("match_regex", 2, fn_match_regex);
+        bind_native!("matchRegex", 2, fn_match_regex);
         bind_native!("max", 1, fn_max);
         bind_native!("merge", 1, fn_merge);
         bind_native!("min", 1, fn_min);
@@ -718,7 +718,7 @@ mod tests {
         let arena = Bump::new();
 
         // Test case with a valid postal code
-        let jsonata = JsonAta::new(r#"$match_regex("123456789", "^[0-9]{9}$")"#, &arena).unwrap();
+        let jsonata = JsonAta::new(r#"$matchRegex("123456789", "^[0-9]{9}$")"#, &arena).unwrap();
         let result = jsonata.evaluate(None, None).unwrap();
 
         // Assert that the result is the postal code itself, indicating a valid match
@@ -726,7 +726,7 @@ mod tests {
 
         // Test case with an invalid postal code
         let jsonata_invalid =
-            JsonAta::new(r#"$match_regex("12345-6789", "^[0-9]{9}$")"#, &arena).unwrap();
+            JsonAta::new(r#"$matchRegex("12345-6789", "^[0-9]{9}$")"#, &arena).unwrap();
 
         let result_invalid = jsonata_invalid.evaluate(None, None);
 


### PR DESCRIPTION
Part of the larger regex support: Add support for regex expressions #96

Note: _This function doesn't handle test specification regex patterns'(skip) use cases, which will be handled separately._ 

Handle a custom regex pattern just like the jsonata js counterpart does.

jsonate-js regex pattern
```
$exists($.postalCode) ? (
        $.postalCode ~> /^[0-9]{9}$/ ? $.postalCode : $assert($.receiver.taxId, "Billing Provider Postal Code must be a nine-digit Zip+4 value without a dash or hyphen.")
)
```

can be re-written as

```
$exists($.postalCode) ? (
    $matchRegex($.postalCode, "^[0-9]{9}$") 
        ? $.postalCode 
        : $assert($.receiver.taxId, "Billing Provider Postal Code must be a nine-digit Zip+4 value without a dash or hyphen.")
) : null
```
