### PR TITLE
fix: using the default token prevents the release PR from having PR checks run

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -48,5 +48,5 @@ jobs:
         with:
           command: release-pr
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PUBLIC_PACKAGE_GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -50,7 +50,7 @@ jobs:
     needs: [tests, fmt_lint, test_wasm]
     # Skipping this results job results in a misleading status on PRs and in the queue,
     # so instead lets always return an explicit success or failure.
-    if: ${{ always() && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) }}
+    if: ${{ always() }}
     steps:
       - name: Collect results on success
         if: ${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}


### PR DESCRIPTION
also: don't exclude the build step on draft PRs.