### PR TITLE
chore: release v0.1.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.1.10](https://github.com/Stedi/jsonata-rs/compare/v0.1.9...v0.1.10) - 2024-10-31
+
+### Added
+
+- support a custom fn to handle regex pattern ([#97](https://github.com/Stedi/jsonata-rs/pull/97))
+
+### Fixed
+
+- using the default token prevents the release PR from having PR checks run ([#101](https://github.com/Stedi/jsonata-rs/pull/101))
+
+### Other
+
+- Automate Release Pipeline || Test Token Update ([#94](https://github.com/Stedi/jsonata-rs/pull/94))
+- clean up README.md and status.md ([#99](https://github.com/Stedi/jsonata-rs/pull/99))
+- add release-plz workflow ([#98](https://github.com/Stedi/jsonata-rs/pull/98))
+
 ### Added
 
 - Context and positional binds

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jsonata-rs"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Stedi"]


### PR DESCRIPTION
## 🤖 New release
* `jsonata-rs`: 0.1.9 -> 0.1.10 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.10](https://github.com/Stedi/jsonata-rs/compare/v0.1.9...v0.1.10) - 2024-10-31

### Added

- support a custom fn to handle regex pattern ([#97](https://github.com/Stedi/jsonata-rs/pull/97))

### Fixed

- using the default token prevents the release PR from having PR checks run ([#101](https://github.com/Stedi/jsonata-rs/pull/101))

### Other

- Automate Release Pipeline || Test Token Update ([#94](https://github.com/Stedi/jsonata-rs/pull/94))
- clean up README.md and status.md ([#99](https://github.com/Stedi/jsonata-rs/pull/99))
- add release-plz workflow ([#98](https://github.com/Stedi/jsonata-rs/pull/98))

### Added

- Context and positional binds
- `$sort` and `$join` functions
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).