### PR TITLE
chore: release v0.1.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.1.11](https://github.com/Stedi/jsonata-rs/compare/v0.1.10...v0.1.11) - 2024-10-31
+
+### Other
+
+- add OSSF Scorecard and badge ([#105](https://github.com/Stedi/jsonata-rs/pull/105))
+- update secrets env var ([#103](https://github.com/Stedi/jsonata-rs/pull/103))
+
 ## [0.1.10](https://github.com/Stedi/jsonata-rs/compare/v0.1.9...v0.1.10) - 2024-10-31
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jsonata-rs"
-version = "0.1.10"
+version = "0.1.11"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Stedi"]


### PR DESCRIPTION
## 🤖 New release
* `jsonata-rs`: 0.1.10 -> 0.1.11 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.11](https://github.com/Stedi/jsonata-rs/compare/v0.1.10...v0.1.11) - 2024-10-31

### Other

- add OSSF Scorecard and badge ([#105](https://github.com/Stedi/jsonata-rs/pull/105))
- update secrets env var ([#103](https://github.com/Stedi/jsonata-rs/pull/103))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).