### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.2.0](https://github.com/Stedi/jsonata-rs/compare/v0.1.10...v0.2.0) - 2024-11-01
+
+### Added
+
+- support additional functions ([#110](https://github.com/Stedi/jsonata-rs/pull/110))
+- support parsing regex literals ([#111](https://github.com/Stedi/jsonata-rs/pull/111))
+
+### Fixed
+
+- used steps in the wrong order ([#117](https://github.com/Stedi/jsonata-rs/pull/117))
+- use app token when checking out repo so that PR triggers will run ([#116](https://github.com/Stedi/jsonata-rs/pull/116))
+
+### Other
+
+- github app ([#115](https://github.com/Stedi/jsonata-rs/pull/115))
+- remove github token from action ([#113](https://github.com/Stedi/jsonata-rs/pull/113))
+- add non_exhaustive to the Error enum ([#112](https://github.com/Stedi/jsonata-rs/pull/112))
+- create CODEOWNERS; add security policy ([#109](https://github.com/Stedi/jsonata-rs/pull/109))
+- add OSV-scanner ([#107](https://github.com/Stedi/jsonata-rs/pull/107))
+- add OSSF Scorecard and badge ([#105](https://github.com/Stedi/jsonata-rs/pull/105))
+- update secrets env var ([#103](https://github.com/Stedi/jsonata-rs/pull/103))
+
 ## [0.1.10](https://github.com/Stedi/jsonata-rs/compare/v0.1.9...v0.1.10) - 2024-10-31
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jsonata-rs"
-version = "0.1.10"
+version = "0.2.0"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Stedi"]


### PR DESCRIPTION
## 🤖 New release
* `jsonata-rs`: 0.1.10 -> 0.2.0 (⚠️ API breaking changes)

### ⚠️ `jsonata-rs` breaking changes

```
--- failure enum_marked_non_exhaustive: enum marked #[non_exhaustive] ---

Description:
A public enum has been marked #[non_exhaustive]. Pattern-matching on it outside of its crate must now include a wildcard pattern like `_`, or it will fail to compile.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#attr-adding-non-exhaustive
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/enum_marked_non_exhaustive.ron

Failed in:
  enum Error in /tmp/.tmpkGnC0x/jsonata-rs/src/errors.rs:7
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.0](https://github.com/Stedi/jsonata-rs/compare/v0.1.10...v0.2.0) - 2024-11-01

### Added

- support additional functions ([#110](https://github.com/Stedi/jsonata-rs/pull/110))
- support parsing regex literals ([#111](https://github.com/Stedi/jsonata-rs/pull/111))

### Fixed

- used steps in the wrong order ([#117](https://github.com/Stedi/jsonata-rs/pull/117))
- use app token when checking out repo so that PR triggers will run ([#116](https://github.com/Stedi/jsonata-rs/pull/116))

### Other

- github app ([#115](https://github.com/Stedi/jsonata-rs/pull/115))
- remove github token from action ([#113](https://github.com/Stedi/jsonata-rs/pull/113))
- add non_exhaustive to the Error enum ([#112](https://github.com/Stedi/jsonata-rs/pull/112))
- create CODEOWNERS; add security policy ([#109](https://github.com/Stedi/jsonata-rs/pull/109))
- add OSV-scanner ([#107](https://github.com/Stedi/jsonata-rs/pull/107))
- add OSSF Scorecard and badge ([#105](https://github.com/Stedi/jsonata-rs/pull/105))
- update secrets env var ([#103](https://github.com/Stedi/jsonata-rs/pull/103))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).