### PR TITLE
feat: support parsing regex literals

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -135,6 +135,7 @@ mod tests {
     #[test_case("Account4.Order.Product^(>Price, <Quantity)" ; "sort 3")]
     #[test_case("Account5.Order.Product^(Price * Quantity)" ; "sort 4")]
     #[test_case("student[type='fulltime']^(DoB).name" ; "sort 5")]
+    #[test_case("/[0-9]+/" ; "regex literal")]
     #[test_case(
         r#"
         Invoice.(
@@ -271,6 +272,6 @@ mod tests {
     "# ; "complex expression"
     )]
     fn parser_tests(source: &str) {
-        let _ = parse(source);
+        parse(source).expect("failed to parse");
     }
 }

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -1,4 +1,5 @@
-use super::RegexLiteral;
+// Re-export for use in evaluator.
+pub use super::expressions::RegexLiteral;
 
 // Object constructor, represented by tuples of (key, value)
 pub type Object = Vec<(Ast, Ast)>;

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -1,3 +1,5 @@
+use super::RegexLiteral;
+
 // Object constructor, represented by tuples of (key, value)
 pub type Object = Vec<(Ast, Ast)>;
 
@@ -73,6 +75,7 @@ pub enum AstKind {
     Bool(bool),
     String(String),
     Number(f64),
+    Regex(RegexLiteral),
     Name(String),
     Var(String),
     Unary(UnaryOp),

--- a/src/parser/expressions.rs
+++ b/src/parser/expressions.rs
@@ -1,3 +1,5 @@
+use std::ops::Deref;
+
 pub fn check_balanced_brackets(expr: &str) -> Result<(), String> {
     let mut bracket_count = 0;
     let mut i = 0;
@@ -36,4 +38,28 @@ pub fn check_balanced_brackets(expr: &str) -> Result<(), String> {
     }
 
     Ok(())
+}
+
+/// A wrapper type for a regex literal so that we can implement PartialEq
+#[derive(Debug, Clone)]
+pub struct RegexLiteral(regex::Regex);
+
+impl RegexLiteral {
+    pub(super) fn new(regex: regex::Regex) -> Self {
+        Self(regex)
+    }
+}
+
+impl Deref for RegexLiteral {
+    type Target = regex::Regex;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl PartialEq for RegexLiteral {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.as_str() == other.0.as_str()
+    }
 }

--- a/src/parser/symbol.rs
+++ b/src/parser/symbol.rs
@@ -36,6 +36,7 @@ impl Symbol for Token {
             TokenKind::Bool(ref v) => Ok(Ast::new(AstKind::Bool(*v), self.char_index)),
             TokenKind::Str(ref v) => Ok(Ast::new(AstKind::String(v.clone()), self.char_index)),
             TokenKind::Number(v) => Ok(Ast::new(AstKind::Number(v), self.char_index)),
+            TokenKind::Regex(ref v) => Ok(Ast::new(AstKind::Regex(v.clone()), self.char_index)),
             TokenKind::Name(ref v) => Ok(Ast::new(AstKind::Name(v.clone()), self.char_index)),
             TokenKind::Var(ref v) => Ok(Ast::new(AstKind::Var(v.clone()), self.char_index)),
             TokenKind::And => Ok(Ast::new(


### PR DESCRIPTION
This doesn't yet add support for doing anything wiht them – the evaluator still panics when it reaches one.

```
thread 'main' panicked at src/evaluator.rs:135:18:
not implemented: TODO: node kind not yet supported: Regex(
    RegexLiteral(
        Regex(
            "[0-9]",
        ),
    ),
)
```


Note: we should probably switch from `regex` to https://docs.rs/regress/latest/regress/ , which targets the javascript regex syntax, which I assume JSONata uses (or at least is closer to).