### PR TITLE
chore: revert upload-artifact update

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -55,7 +55,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v3.pre.node20
+        uses: actions/upload-artifact@97a0fba1372883ab732affbe8f94b823f91727db # v3.pre.node20
         with:
           name: SARIF file
           path: results.sarif


### PR DESCRIPTION
reverting an update of `actions/upload-artifact` as the updated version doesnt seem allowlisted by ossf:

- failed run https://github.com/Stedi/jsonata-rs/actions/runs/11662165210/job/32467973390
- ossf documentation: https://github.com/ossf/scorecard-action#workflow-restrictions