### PR TITLE
Revert "chore: exempt CHANGELOG from codeowners (#121)"

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,4 +7,3 @@ Cargo.lock
 **/Cargo.toml
 .github/**/*.yml
 .github/**/*.yaml
-CHANGELOG.md


### PR DESCRIPTION
Intent is not to automerge the release PRs.

This reverts commit 80880921ac42e631ade3745d9685c640a2d32360.
