### PR TITLE
chore: pin dependency fix for rust toolchain

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -30,7 +30,9 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.generate-token.outputs.token }}
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1482605bfc5719782e1267fd0c0cc350fe7646b8 # stable
+        with:
+          toolchain: stable
       - name: Run release-plz release
         uses: MarcoIeni/release-plz-action@301fd6d8c641b97f25b5ade37651a478a5faa7da # v0.5
         with:
@@ -64,7 +66,9 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.generate-token.outputs.token }}
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1482605bfc5719782e1267fd0c0cc350fe7646b8 # stable
+        with:
+          toolchain: stable
       - name: Run release-plz PR task
         uses: MarcoIeni/release-plz-action@301fd6d8c641b97f25b5ade37651a478a5faa7da # v0.5
         with:

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -18,7 +18,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1482605bfc5719782e1267fd0c0cc350fe7646b8 # stable
+        with:
+          toolchain: stable
       - run: cargo test --all-features -- --nocapture
 
   test_wasm:
@@ -26,8 +28,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1482605bfc5719782e1267fd0c0cc350fe7646b8 # stable
         with:
+          toolchain: stable
           target: wasm32-wasi
       - uses: taiki-e/install-action@9c04113bd63f9659d7a53908386758275ab35630
         with:
@@ -43,8 +46,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1482605bfc5719782e1267fd0c0cc350fe7646b8 # stable
         with:
+          toolchain: stable
           components: rustfmt, clippy
       - name: Cargo fmt
         run: cargo fmt --all --check

--- a/.github/workflows/validate-renovate-config.yml
+++ b/.github/workflows/validate-renovate-config.yml
@@ -24,7 +24,7 @@ jobs:
           node-version: 18
 
       - name: Install Renovate
-        run: npm install -g renovate
+        run: npm install -g renovate@39.9.3
 
       - name: Validate repo Renovate config
         run: renovate-config-validator


### PR DESCRIPTION
pin dependencies in github actions https://github.com/Stedi/jsonata-rs/issues/132

Scorecard(Locally)

<img width="1708" alt="image" src="https://github.com/user-attachments/assets/da2d627b-e13e-4c01-a545-8c9c0187e1c6">


**_Note - Observation:_**

npm doesn’t support hash-based pinning like GitHub Actions do. I tried few things but the node_module build itself propagates warning.
Here what i tried:
Create a package.json in .github/workflows directory.
Define renovate as a dependency with a specific version.
Commit the generated package-lock.json to lock the version and all sub-dependencies.
and in workflow add
- name: Install Renovate
  run: npm ci --prefix .github/workflows

![image](https://github.com/user-attachments/assets/0c274641-eb8e-412c-a379-97b78d5fe6e9)

