### PR TITLE
chore: bump up actions workflow in osv scanner

### DIFF
--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -21,6 +21,8 @@ jobs:
   scan-scheduled:
     permissions:
       contents: read
+      actions: read
+      security-events: write
     if: ${{ github.event_name == 'push' || github.event_name == 'schedule' }}
     uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@19ec1116569a47416e11a45848722b1af31a857b" # v1.9.0
     with:

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -43,6 +43,8 @@ jobs:
   scan-pr:
     permissions:
       contents: read
+      actions: read
+      security-events: write
     if: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
     uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@19ec1116569a47416e11a45848722b1af31a857b" # v1.9.0
     with:


### PR DESCRIPTION
Fix: https://github.com/Stedi/jsonata-rs/actions/runs/11806953756

`[Invalid workflow file: .github/workflows/osv-scanner.yml#L21](https://github.com/Stedi/jsonata-rs/actions/runs/11806953756/workflow)
The workflow is not valid. .github/workflows/osv-scanner.yml (Line: 21, Col: 3): Error calling workflow 'google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@19ec1116569a47416e11a45848722b1af31a857b'. The workflow is requesting 'actions: read, security-events: write', but is only allowed 'actions: none, security-events: none'.`