### PR TITLE
fix: some type-errors in function calls caused panics

### DIFF
--- a/src/evaluator/functions.rs
+++ b/src/evaluator/functions.rs
@@ -1011,22 +1011,19 @@ pub fn from_millis<'a>(
     };
 
     let (picture, timezone) = match args {
-        [_, picture, timezone] => (
-            if picture.is_string() {
-                picture.as_str()
-            } else {
-                Cow::Borrowed("") // Treat non-strings (like ()) as empty strings
-            },
-            timezone.as_str(),
-        ),
-        [_, picture] => (
-            if picture.is_string() {
-                picture.as_str()
-            } else {
-                Cow::Borrowed("")
-            },
-            Cow::Borrowed(""),
-        ),
+        [_, picture, timezone] if picture.is_undefined() => {
+            assert_arg!(timezone.is_string(), context, 3);
+            (Cow::Borrowed(""), timezone.as_str())
+        }
+        [_, picture, timezone] => {
+            assert_arg!(picture.is_string(), context, 2);
+            assert_arg!(timezone.is_string(), context, 3);
+            (picture.as_str(), timezone.as_str())
+        }
+        [_, picture] => {
+            assert_arg!(picture.is_string(), context, 2);
+            (picture.as_str(), Cow::Borrowed(""))
+        }
         _ => (Cow::Borrowed(""), Cow::Borrowed("")),
     };
 

--- a/src/evaluator/functions.rs
+++ b/src/evaluator/functions.rs
@@ -1104,6 +1104,7 @@ pub fn to_millis<'a>(
     }
 
     max_args!(context, args, 2);
+    assert_arg!(args[0].is_string(), context, 1);
 
     // Extract the timestamp string
     let timestamp_str = args[0].as_str();
@@ -1113,7 +1114,11 @@ pub fn to_millis<'a>(
 
     // Extract the optional picture string
     let picture = match args {
-        [_, picture] => picture.as_str(),
+        [_, picture] if picture.is_undefined() => Cow::Borrowed(""),
+        [_, picture] => {
+            assert_arg!(picture.is_string(), context, 2);
+            picture.as_str()
+        }
         _ => Cow::Borrowed(""),
     };
 

--- a/src/evaluator/functions.rs
+++ b/src/evaluator/functions.rs
@@ -1002,12 +1002,13 @@ pub fn from_millis<'a>(
     }
 
     max_args!(context, args, 3);
+    assert_arg!(args[0].is_number(), context, 1);
+
     let millis = args[0].as_f64() as i64;
 
-    let timestamp = Utc
-        .timestamp_millis_opt(millis)
-        .single()
-        .ok_or_else(|| Error::T0410ArgumentNotValid(0, 1, context.name.to_string()))?;
+    let Some(timestamp) = Utc.timestamp_millis_opt(millis).single() else {
+        bad_arg!(context, 1);
+    };
 
     let (picture, timezone) = match args {
         [_, picture, timezone] => (

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -758,4 +758,21 @@ mod tests {
         ));
         assert_eq!(result_invalid, empty_array);
     }
+
+    #[test]
+    fn evaluate_expect_type_errors() {
+        for expr in [
+            "$fromMillis('foo')",
+            "$fromMillis(1, 1)",
+            "$fromMillis(1, '', 1)",
+            "$toMillis(1)",
+            "$toMillis('1970-01-01T00:00:00.000Z', 1)",
+        ] {
+            let arena = Bump::new();
+            let jsonata = JsonAta::new(expr, &arena).unwrap();
+            let err = jsonata.evaluate(None, None).unwrap_err();
+
+            assert_eq!(err.code(), "T0410", "Expected type error from {expr}");
+        }
+    }
 }


### PR DESCRIPTION
safely checks the arg types of `$toMillis` and `$fromMillis`.

Also fixes a compatibility issue: a non-string picture string to `fromMillis` should error instead of being silently ignored.