### PR TITLE
fix: reduce stack memory usage by boxing more regex types

### DIFF
--- a/src/evaluator/value.rs
+++ b/src/evaluator/value.rs
@@ -51,7 +51,7 @@ pub enum Value<'a> {
     Number(f64),
     Bool(bool),
     String(BumpString<'a>),
-    Regex(RegexLiteral),
+    Regex(std::boxed::Box<RegexLiteral>),
     Array(BumpVec<'a, &'a Value<'a>>, ArrayFlags),
     Object(HashMap<BumpString<'a>, &'a Value<'a>, DefaultHashBuilder, &'a Bump>),
     Range(Range<'a>),

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -76,7 +76,7 @@ pub enum AstKind {
     Bool(bool),
     String(String),
     Number(f64),
-    Regex(RegexLiteral),
+    Regex(Box<RegexLiteral>),
     Name(String),
     Var(String),
     Unary(UnaryOp),

--- a/src/parser/symbol.rs
+++ b/src/parser/symbol.rs
@@ -36,7 +36,7 @@ impl Symbol for Token {
             TokenKind::Bool(ref v) => Ok(Ast::new(AstKind::Bool(*v), self.char_index)),
             TokenKind::Str(ref v) => Ok(Ast::new(AstKind::String(v.clone()), self.char_index)),
             TokenKind::Number(v) => Ok(Ast::new(AstKind::Number(v), self.char_index)),
-            TokenKind::Regex(ref v) => Ok(Ast::new(AstKind::Regex(*v.clone()), self.char_index)),
+            TokenKind::Regex(ref v) => Ok(Ast::new(AstKind::Regex(v.clone()), self.char_index)),
             TokenKind::Name(ref v) => Ok(Ast::new(AstKind::Name(v.clone()), self.char_index)),
             TokenKind::Var(ref v) => Ok(Ast::new(AstKind::Var(v.clone()), self.char_index)),
             TokenKind::And => Ok(Ast::new(


### PR DESCRIPTION
the RegexLiteral type is very large, which causes every Ast node and
Symbol to take up significantly more space than needed. This change
reduces the size of AstKind from 144 to 64 bytes, and Value from 144 to
56.
