### PR TITLE
fix: wasm32-wasi has been deprecated

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.wasm32-wasip1]
+runner = "wasmtime --dir=."

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -31,13 +31,11 @@ jobs:
       - uses: dtolnay/rust-toolchain@315e265cd78dad1e1dcf3a5074f6d6c47029d5aa # stable
         with:
           toolchain: stable
-          target: wasm32-wasi
+          target: wasm32-wasip1
       - uses: taiki-e/install-action@c4bf614c2fb42375baf4f51283c33befce095fc5
         with:
-          tool: wasmtime,cargo-wasi
-      - env:
-          CARGO_TARGET_WASM32_WASI_RUNNER: "wasmtime --dir=."
-        run: cargo wasi test -- --nocapture
+          tool: wasmtime
+      - run: cargo test --target wasm32-wasip1
 
   fmt_lint:
     permissions:


### PR DESCRIPTION
The `wasm32-wasi` target has been renamed to `wasm32-wasip1`:

<https://blog.rust-lang.org/2024/04/09/updates-to-rusts-wasi-targets.html>

The `cargo-wasi` crate is also outdated and being replaced with
`cargo-component` for creating WASI components. It does not support the
new target name.
<https://github.com/bytecodealliance/cargo-wasi/issues/143>

However, this project doesn't currently define a WASI component, so we
can't use cargo-component to build or run tests. We do want to verify
that the project builds correctly for the WASM targets, so this change
runs the compiled test targets directly with `wasmtime`.
