### PR TITLE
ci: migrate release-plz action to renamed release-plz/action (ITS-1642)

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -41,7 +41,7 @@ jobs:
           fi
         shell: bash
       - name: Run release-plz release
-        uses: MarcoIeni/release-plz-action@e592230ad39e3ec735402572601fc621aa24355c # v0.5
+        uses: release-plz/action@e592230ad39e3ec735402572601fc621aa24355c # v0.5
         with:
           command: release
         env:
@@ -84,7 +84,7 @@ jobs:
           fi
         shell: bash
       - name: Run release-plz PR task
-        uses: MarcoIeni/release-plz-action@e592230ad39e3ec735402572601fc621aa24355c # v0.5
+        uses: release-plz/action@e592230ad39e3ec735402572601fc621aa24355c # v0.5
         with:
           command: release-pr
         env:


### PR DESCRIPTION
Linear: ITS-1642 — part of the allowed-Actions review ITS-1466

## What changed
`MarcoIeni/release-plz-action` was renamed upstream to `release-plz/action`. This PR updates the two `uses:` references in `.github/workflows/release-plz.yml` (the `release-plz-release` and `release-plz-pr` jobs) to point at the new repo path, keeping the exact same pinned SHA (`e592230ad39e3ec735402572601fc621aa24355c`, `v0.5`). No input/behavior changes — pure rename.

This lets the org's Actions allow-list drop the now-stale `MarcoIeni/release-plz-action` entry in a follow-up it-tooling PR.

## Manual verification for reviewer
- Confirm `release-plz/action` resolves to the same upstream project/commit history as `MarcoIeni/release-plz-action` (GitHub repo rename redirect).
- After merge, watch the next push-to-main run of the `Release` workflow to confirm both jobs (`release-plz-release`, `release-plz-pr`) still resolve and run the action successfully.

## Merge-order constraint
Do **not** merge this PR until the it-tooling PR adding `release-plz/action@*` to the org Actions allow-list has been merged — otherwise this workflow will be blocked org-wide once it runs on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)