### PR TITLE
ci: pin GitHub Actions refs to releases with version comments

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -50,7 +50,7 @@ jobs:
       - run: |
           : install wasm32-wasip1 target
           rustup target add wasm32-wasip1
-      - uses: taiki-e/install-action@b5747eed99979fc88373babc6a36a03e25d6f87b
+      - uses: taiki-e/install-action@3f67faa728964808f52294a9cd15561b15550b28 # v2.67.19
         with:
           tool: wasmtime
       - run: cargo test --target wasm32-wasip1

--- a/.github/workflows/validate-renovate-config.yml
+++ b/.github/workflows/validate-renovate-config.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 18
 


### PR DESCRIPTION
## What changed

Every SHA-pinned `uses:` ref in this repo's workflows and composite actions now carries a trailing
hint:

```yaml
uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
```

Only `uses:` lines changed — no inputs, no `permissions:`, no step ids. This covers
`.github/workflows/` **and** `.github/actions/` composite actions, which is where a lot of these refs
actually live.

## Why the comment is load-bearing

Renovate's `github-actions` manager derives `currentValue` for a SHA-pinned action **only** from the
trailing comment. A bare SHA yields no `currentValue`, so the dep is marked
`skipReason: 'unversioned-reference'`, disabled **before** the lookup stage, and never updated — it
does not even show up under "Detected Dependencies" on the Dependency Dashboard. Because skipped deps
are filtered out pre-lookup, this **cannot** be fixed with `packageRules`.

So a bare SHA pin was not "pinned and maintained". It was frozen and invisible.

## How each ref was resolved

Three rules, applied per ref:

1. **The SHA is exactly a release** → SHA untouched, `# vX.Y.Z` added. Purely additive.
2. **The SHA is an untagged commit** → the ref moves to the *earliest full release that contains that
   commit*, and is commented with it. This is the only case where the executing code changes, and it
   moves forward by the smallest possible amount rather than jumping to latest.
3. **The SHA is newer than every release** → SHA untouched, commented with the action's **actual
   default branch** (`# main` or `# master`), which makes Renovate track the branch head via
   `github-digest` instead of proposing tagged releases.

Rule 2 exists because a surprising number of these pins were never releases at all —
`actions/checkout@0c366fd6` is the commit *"Update changelog (#2357)"*, and
`actions/download-artifact@484a0b52` is literally current `main` HEAD. Those refs were running
unreleased upstream code, permanently.

Alias tags are deliberately excluded when resolving rule 2: a bare `v6` points at the current v6
head, not a release, so it would give a wrong answer. Only full `vN.M.P` tags are candidates, and
containment is verified with `compare/{sha}...{tag}`.

## You may also see `# v2` become `# v2.0.3`

A few refs already had a comment, but a **floating alias** one (`# v6`, `# v2`). Those were visible to
Renovate, just coarsely: `currentValue: "v2"` only moves when the major moves, so you never get
patch-level PRs. Where such a ref shares a SHA with one being fixed here, its comment is sharpened to
the exact release. **The SHA is byte-identical in every one of those cases** — comment only, no
behaviour change.

## Why these versions and not latest

The target is the *earliest* release containing the pinned commit, not the newest release. That keeps
this PR about **visibility**, not about upgrading. Once Renovate can see these refs it will propose
the remaining upgrades itself, on the org's normal schedule and `minimumReleaseAge` cooldown, in
reviewable increments.

## Verification

Each repo is gated before its PR is opened by a line-for-line port of Renovate's
`parse.ts`/`extract.ts`, which must report **zero** invisible refs or no PR is created. That port was
validated against real `renovate --dry-run=extract` on three repos (73/73, 173/173, 50/50 deps, exact
across all outcome classes).

A useful cross-check fell out of the resolution: three rule-2 targets independently landed on a SHA
this org already pins elsewhere with the identical version comment — e.g. every `runs-on/action` ref
in the org converges on `e46a3c6d62a5 # v2.1.1`, which is what `Stedi/healthcare` already used.

## For the reviewer

- [ ] CI green. If this repo's refs are all rule 1/3 the SHAs are **byte-identical** to before, so
      behaviour cannot have changed — the diff is comments only.
- [ ] If any ref moved (rule 2), confirm the affected jobs still behave: toolchain caching still hits,
      artifacts still upload/download, deploys still run.
- [ ] A cache *miss* shows up as a slower build rather than a failure — worth a glance at step timings
      on the first run.

**This PR is intentionally a draft.** Marking it ready and merging is your call, per repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)