### PR TITLE
fix(deps): update high-confidence-rust-minor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,10 +21,10 @@ bumpalo = { version = "3.16.0", features = [
 chrono = "0.4.38"
 clap = { version = "4.5.4", features = ["derive"] }
 dtoa = "1.0.9"
-hashbrown = "0.15.0"
+hashbrown = "0.17.1"
 num-format = "0.4.4"
-rand = "0.9.0"
-regress = "0.10.1"
+rand = "0.10.0"
+regress = "0.11.1"
 serde_json = "1.0.117"
 uuid = { version = "1.8.0", features = ["fast-rng", "v4", "v7"] }
 
@@ -32,6 +32,6 @@ uuid = { version = "1.8.0", features = ["fast-rng", "v4", "v7"] }
 glob = "0.3"
 
 [dev-dependencies]
-regress = "=0.10.3"
+regress = "=0.11.1"
 test-case = "=3.3.1"
 test-generator = "=0.3.1"

--- a/src/evaluator/functions.rs
+++ b/src/evaluator/functions.rs
@@ -1,7 +1,7 @@
 use base64::Engine;
 use chrono::{TimeZone, Utc};
 use hashbrown::{DefaultHashBuilder, HashMap};
-use rand::Rng;
+use rand::RngExt;
 use regress::{Range, Regex};
 use std::borrow::{Borrow, Cow};
 use std::collections::HashSet;

--- a/src/evaluator/value/impls.rs
+++ b/src/evaluator/value/impls.rs
@@ -3,7 +3,7 @@ use std::{
     ops::Index,
 };
 
-use rand::Rng;
+use rand::RngExt;
 
 use super::Value;
 


### PR DESCRIPTION
Supersedes #181, which proposed the same dependency bumps but has been failing CI since March and had gone stale against `main`. Its CI logs have since expired, so the failure was reproduced from scratch.

## Bumps

| Package | From | To | Released |
|---|---|---|---|
| `hashbrown` | 0.15.0 | 0.17.1 | 2026-05-09 |
| `rand` | 0.9.0 | 0.10.0 | 2026-02-08 |
| `regress` | 0.10.1 | 0.11.1 | 2026-03-29 |

All three are well past the 21-day `minimumReleaseAge` in `renovate.json`. `regress` 0.12.0 exists but is only 15 days old, so it was deliberately left for Renovate to pick up after 2026-09-13.

## Why #181 failed

`rand` 0.10 moved the generator convenience methods off the `Rng` trait into a new `RngExt` trait, so `rand::rng().random()` no longer resolves with only `Rng` in scope:

```
error[E0599]: no method named `random` found for struct `ThreadRng` in the current scope
    --> src/evaluator/functions.rs:1201:30
help: trait `RngExt` which provides `random` is implemented but not in scope
```

Fixed by importing `RngExt` at the two call sites (`src/evaluator/functions.rs`, `src/evaluator/value/impls.rs`). `hashbrown` and `regress` needed no source changes.

## Verification

Locally, on top of current `main`:

- `cargo build --all-targets` — clean
- `cargo test --all-features` — 837 passed, 0 failed, 395 ignored
- `cargo fmt --all --check` — clean

`cargo clippy` reports 5 pre-existing findings (4x `unnecessary_cast`, 1x `collapsible_match`), but those reproduce identically on unmodified `main` under a newer toolchain than the pinned 1.92.0 and are unrelated to these bumps, so they are left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)